### PR TITLE
Add watchdev command and an nginx.insecure.conf for development

### DIFF
--- a/docker_build/nginx.insecure.conf
+++ b/docker_build/nginx.insecure.conf
@@ -1,0 +1,61 @@
+user                            www;
+error_log                       /dev/stdout debug;
+pid                             /var/run/nginx.pid; # it permit you to use /etc/init.d/nginx reload|restart|stop|start
+
+events {
+    worker_connections          1024;
+}
+
+http {
+    upstream apibackend {
+        keepalive 100;
+        server api:5000;
+    }
+
+    server {
+        include                 /etc/nginx/mime.types;
+        access_log              /dev/stdout;
+        keepalive_timeout       3000;
+        index                   index.html;
+        listen                  80;
+        # ssl_certificate         /opt/faction/certs/api.pem;
+        # ssl_certificate_key     /opt/faction/certs/api.key;
+
+        client_max_body_size    1g;
+        error_page              500 502 503 504  /50x.html;
+
+        root                    /var/www/;
+
+        proxy_connect_timeout 60s;
+        proxy_read_timeout 1d;
+        proxy_send_timeout 10m;
+
+
+        location / {
+            add_header X-Faction RocksSocks;
+            try_files $uri $uri/ /index.html;
+        }
+
+
+        location /api/v1/ {
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://apibackend;
+        }
+
+        location /socket.io {
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_buffering off;
+            proxy_redirect off;
+            proxy_pass http://apibackend/socket.io;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "watchdev": "vue-cli-service build --no-clean --watch --mode development",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
The watchdev command is useful for when you do not want to use npm run serve and instead want to actually build, but in development. It can also be leveraged in syncing host file to docker containers for easier development. The nginx.insecure.conf file is just a nginx conf for non-ssl which can be mounted inside a container easier development.